### PR TITLE
fix a typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ conda deactivate
 # Running The Project
 ```bash
 cd script
-python manage.py runserver --settings=script.settings
+python manage.py runserver --settings=app.settings
 ```
 
 Then navigate to localhost:8000 on your browser


### PR DESCRIPTION
### Why:
The setting path is a liitle bit problematic.

### What:
Change the Django setting path in readme.

### Checklist
- [x] Finished My Changes
- [ ] Automated Unit Tests
