### PR TITLE
bug fix, chart naming changed

### DIFF
--- a/frontend/src/Components/AlgInputs/AlgInputsLoadForecast.js
+++ b/frontend/src/Components/AlgInputs/AlgInputsLoadForecast.js
@@ -117,10 +117,17 @@ class AlgInputsLoadForecast extends Component {
     };
 
     updateChartTitles = () => {
-        this.props.setChartTitles([
-            `${this.state.configName} - ${this.state.countyChoice} uncontrolled`,
-            `${this.state.configName} - ${this.state.countyChoice} ${this.state.workControl} controlled`,
-        ]);
+        if (this.state.aggregationLevel == "county") {
+            this.props.setChartTitles([
+                `${this.state.configName} - ${this.state.countyChoice} uncontrolled`,
+                `${this.state.configName} - ${this.state.countyChoice} ${this.state.workControl} controlled`,
+            ]);
+        } else {
+            this.props.setChartTitles([
+                `${this.state.configName} - state uncontrolled`,
+                `${this.state.configName} - state ${this.state.workControl} controlled`,
+            ]);
+        }
     };
 
     getResult = async () => {


### PR DESCRIPTION
Resolves the graph naming issue for when the aggregation type is state instead of county
